### PR TITLE
[feat] 카메라 유스케이스

### DIFF
--- a/Wasap/Wasap.xcodeproj/project.pbxproj
+++ b/Wasap/Wasap.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		6FAE7ACB2CADA1CB00A1D1CE /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 6FAE7ACA2CADA1CB00A1D1CE /* RxRelay */; };
 		6FAE7ACD2CADA1CB00A1D1CE /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 6FAE7ACC2CADA1CB00A1D1CE /* RxSwift */; };
 		6FAE7AD02CADA1DB00A1D1CE /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6FAE7ACF2CADA1DB00A1D1CE /* SnapKit */; };
+		6FEE9B002CB3BC11004B9A01 /* RxBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = 6FEE9AFF2CB3BC11004B9A01 /* RxBlocking */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,7 +28,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		6F29A3BD2CAF7870005666A4 /* WasapTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WasapTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FAE7AA52CAD9F5600A1D1CE /* Wasap.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wasap.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FB475EA2CB0181700886498 /* WasapTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WasapTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -43,11 +43,6 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		6F29A3BE2CAF7870005666A4 /* WasapTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = WasapTests;
-			sourceTree = "<group>";
-		};
 		6FAE7AA72CAD9F5600A1D1CE /* Wasap */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -64,13 +59,6 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		6F29A3BA2CAF7870005666A4 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		6FAE7AA22CAD9F5600A1D1CE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -89,6 +77,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6FEE9B002CB3BC11004B9A01 /* RxBlocking in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,6 +89,7 @@
 			children = (
 				6FAE7AA72CAD9F5600A1D1CE /* Wasap */,
 				6FB475EB2CB0181700886498 /* WasapTests */,
+				6FEE9AFE2CB3BC11004B9A01 /* Frameworks */,
 				6FAE7AA62CAD9F5600A1D1CE /* Products */,
 			);
 			sourceTree = "<group>";
@@ -113,32 +103,16 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		6FEE9AFE2CB3BC11004B9A01 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		6F29A3BC2CAF7870005666A4 /* WasapTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 6F29A3C32CAF7870005666A4 /* Build configuration list for PBXNativeTarget "WasapTests" */;
-			buildPhases = (
-				6F29A3B92CAF7870005666A4 /* Sources */,
-				6F29A3BA2CAF7870005666A4 /* Frameworks */,
-				6F29A3BB2CAF7870005666A4 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				6F29A3C22CAF7870005666A4 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				6F29A3BE2CAF7870005666A4 /* WasapTests */,
-			);
-			name = WasapTests;
-			packageProductDependencies = (
-			);
-			productName = WasapTests;
-			productReference = 6F29A3BD2CAF7870005666A4 /* WasapTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		6FAE7AA42CAD9F5600A1D1CE /* Wasap */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6FAE7AB82CAD9F5700A1D1CE /* Build configuration list for PBXNativeTarget "Wasap" */;
@@ -186,6 +160,7 @@
 			);
 			name = WasapTests;
 			packageProductDependencies = (
+				6FEE9AFF2CB3BC11004B9A01 /* RxBlocking */,
 			);
 			productName = WasapTests;
 			productReference = 6FB475EA2CB0181700886498 /* WasapTests.xctest */;
@@ -201,10 +176,6 @@
 				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
-					6F29A3BC2CAF7870005666A4 = {
-						CreatedOnToolsVersion = 16.0;
-						TestTargetID = 6FAE7AA42CAD9F5600A1D1CE;
-					};
 					6FAE7AA42CAD9F5600A1D1CE = {
 						CreatedOnToolsVersion = 16.0;
 					};
@@ -240,13 +211,6 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		6F29A3BB2CAF7870005666A4 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		6FAE7AA32CAD9F5600A1D1CE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -264,13 +228,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		6F29A3B92CAF7870005666A4 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		6FAE7AA12CAD9F5600A1D1CE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -296,44 +253,6 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		6F29A3C42CAF7870005666A4 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.teamGOD.WasapTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Wasap.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Wasap";
-			};
-			name = Debug;
-		};
-		6F29A3C52CAF7870005666A4 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.teamGOD.WasapTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Wasap.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Wasap";
-			};
-			name = Release;
-		};
 		6FAE7AB92CAD9F5700A1D1CE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -347,6 +266,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8U8S6CBZ9D;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Wasap/Global/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "와이파이를 잡기 위해 카메라 사용이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
@@ -381,6 +301,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8U8S6CBZ9D;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Wasap/Global/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "와이파이를 잡기 위해 카메라 사용이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
@@ -525,12 +446,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.teamGOD.WasapTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -542,12 +465,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.teamGOD.WasapTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -558,15 +483,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		6F29A3C32CAF7870005666A4 /* Build configuration list for PBXNativeTarget "WasapTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				6F29A3C42CAF7870005666A4 /* Debug */,
-				6F29A3C52CAF7870005666A4 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		6FAE7AA02CAD9F5600A1D1CE /* Build configuration list for PBXProject "Wasap" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -658,6 +574,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6FAE7ACE2CADA1DB00A1D1CE /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
+		};
+		6FEE9AFF2CB3BC11004B9A01 /* RxBlocking */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6FAE7AC72CADA1CB00A1D1CE /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxBlocking;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Wasap/Wasap.xcodeproj/project.pbxproj
+++ b/Wasap/Wasap.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6F29A3BD2CAF7870005666A4 /* WasapTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WasapTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FAE7AA52CAD9F5600A1D1CE /* Wasap.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wasap.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FB475EA2CB0181700886498 /* WasapTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WasapTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -42,6 +43,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		6F29A3BE2CAF7870005666A4 /* WasapTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = WasapTests;
+			sourceTree = "<group>";
+		};
 		6FAE7AA72CAD9F5600A1D1CE /* Wasap */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -58,6 +64,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		6F29A3BA2CAF7870005666A4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6FAE7AA22CAD9F5600A1D1CE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -103,6 +116,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		6F29A3BC2CAF7870005666A4 /* WasapTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6F29A3C32CAF7870005666A4 /* Build configuration list for PBXNativeTarget "WasapTests" */;
+			buildPhases = (
+				6F29A3B92CAF7870005666A4 /* Sources */,
+				6F29A3BA2CAF7870005666A4 /* Frameworks */,
+				6F29A3BB2CAF7870005666A4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6F29A3C22CAF7870005666A4 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				6F29A3BE2CAF7870005666A4 /* WasapTests */,
+			);
+			name = WasapTests;
+			packageProductDependencies = (
+			);
+			productName = WasapTests;
+			productReference = 6F29A3BD2CAF7870005666A4 /* WasapTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		6FAE7AA42CAD9F5600A1D1CE /* Wasap */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6FAE7AB82CAD9F5700A1D1CE /* Build configuration list for PBXNativeTarget "Wasap" */;
@@ -165,6 +201,10 @@
 				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
+					6F29A3BC2CAF7870005666A4 = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = 6FAE7AA42CAD9F5600A1D1CE;
+					};
 					6FAE7AA42CAD9F5600A1D1CE = {
 						CreatedOnToolsVersion = 16.0;
 					};
@@ -200,6 +240,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		6F29A3BB2CAF7870005666A4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6FAE7AA32CAD9F5600A1D1CE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -217,6 +264,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		6F29A3B92CAF7870005666A4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6FAE7AA12CAD9F5600A1D1CE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -242,6 +296,44 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		6F29A3C42CAF7870005666A4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.teamGOD.WasapTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Wasap.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Wasap";
+			};
+			name = Debug;
+		};
+		6F29A3C52CAF7870005666A4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.teamGOD.WasapTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Wasap.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Wasap";
+			};
+			name = Release;
+		};
 		6FAE7AB92CAD9F5700A1D1CE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -466,6 +558,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		6F29A3C32CAF7870005666A4 /* Build configuration list for PBXNativeTarget "WasapTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6F29A3C42CAF7870005666A4 /* Debug */,
+				6F29A3C52CAF7870005666A4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		6FAE7AA02CAD9F5600A1D1CE /* Build configuration list for PBXProject "Wasap" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Wasap/Wasap.xcodeproj/xcshareddata/xcschemes/Wasap.xcscheme
+++ b/Wasap/Wasap.xcodeproj/xcshareddata/xcschemes/Wasap.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6FAE7AA42CAD9F5600A1D1CE"
+               BuildableName = "Wasap.app"
+               BlueprintName = "Wasap"
+               ReferencedContainer = "container:Wasap.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6FB475E92CB0181700886498"
+               BuildableName = "WasapTests.xctest"
+               BlueprintName = "WasapTests"
+               ReferencedContainer = "container:Wasap.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6FAE7AA42CAD9F5600A1D1CE"
+            BuildableName = "Wasap.app"
+            BlueprintName = "Wasap"
+            ReferencedContainer = "container:Wasap.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6FAE7AA42CAD9F5600A1D1CE"
+            BuildableName = "Wasap.app"
+            BlueprintName = "Wasap"
+            ReferencedContainer = "container:Wasap.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Wasap/Wasap.xcodeproj/xcshareddata/xcschemes/WasapTests.xcscheme
+++ b/Wasap/Wasap.xcodeproj/xcshareddata/xcschemes/WasapTests.xcscheme
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6FB475E92CB0181700886498"
+               BuildableName = "WasapTests.xctest"
+               BlueprintName = "WasapTests"
+               ReferencedContainer = "container:Wasap.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Wasap/Wasap/Entity/CameraErrors.swift
+++ b/Wasap/Wasap/Entity/CameraErrors.swift
@@ -1,0 +1,35 @@
+//
+//  CameraErrors.swift
+//  Wasap
+//
+//  Created by chongin on 10/8/24.
+//
+
+enum CameraErrors: Error {
+    case cameraNotFound
+    case unknown
+    case captureDeviceError
+    case imageOutputNotAvailable
+    case photoProcessingError
+    case imageConvertError
+    case previewLayerError
+
+    var localizedDescription: String {
+        switch self {
+        case .cameraNotFound:
+            return "Camera not found"
+        case .unknown:
+            return "Unknown error"
+        case .captureDeviceError:
+            return "Capture device error"
+        case .imageOutputNotAvailable:
+            return "Image output not available"
+        case .photoProcessingError:
+            return "Photo processing error"
+        case .imageConvertError:
+            return "Image convert error"
+        case .previewLayerError:
+            return "Preview layer error"
+        }
+    }
+}

--- a/Wasap/Wasap/Features/Sample/SampleCoordinator.swift
+++ b/Wasap/Wasap/Features/Sample/SampleCoordinator.swift
@@ -16,7 +16,7 @@ public class SampleCoordinator: NavigationCoordinator {
     }
 
     public func start() {
-        let viewController = CameraViewController(cameraUseCase: CameraUseCase(repository: DefaultCameraRepository())) // SAMPLE입니다..!
+        let viewController = CameraViewController(cameraUseCase: DefaultCameraUseCase(repository: DefaultCameraRepository())) // SAMPLE입니다..!
         self.navigationController.pushViewController(viewController, animated: true)
     }
 }

--- a/Wasap/Wasap/Features/Sample/SampleCoordinator.swift
+++ b/Wasap/Wasap/Features/Sample/SampleCoordinator.swift
@@ -16,7 +16,7 @@ public class SampleCoordinator: NavigationCoordinator {
     }
 
     public func start() {
-        let viewController = ViewController() // SAMPLE입니다..!
+        let viewController = CameraViewController(cameraUseCase: CameraUseCase(repository: DefaultCameraRepository())) // SAMPLE입니다..!
         self.navigationController.pushViewController(viewController, animated: true)
     }
 }

--- a/Wasap/Wasap/Features/WifiAutoConnect/Repository/CameraRepository.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/Repository/CameraRepository.swift
@@ -1,0 +1,107 @@
+//
+//  CameraRepository.swift
+//  Wasap
+//
+//  Created by chongin on 10/7/24.
+//
+
+import RxSwift
+import AVFoundation
+
+protocol CameraRepository {
+    func configureCamera() -> Single<AVCaptureSession>
+    func startMonitoring()
+    func stopMonitoring()
+    func capturePhoto() -> Single<Data>
+}
+
+class DefaultCameraRepository: NSObject, CameraRepository {
+    private var captureSession: AVCaptureSession?
+    private var stillImageOutput: AVCapturePhotoOutput?
+    private var photoCaptureCompletion: ((Result<Data, Error>) -> Void)?
+
+    // 카메라 프리뷰 설정
+    func configureCamera() -> Single<AVCaptureSession> {
+        return Single.create { single in
+            let session = AVCaptureSession()
+            session.sessionPreset = .photo
+
+            guard let backCamera = AVCaptureDevice.default(for: .video) else {
+                single(.failure(NSError(domain: "CameraError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Back camera not found"])))
+                return Disposables.create()
+            }
+
+            do {
+                let input = try AVCaptureDeviceInput(device: backCamera)
+                session.addInput(input)
+
+                self.stillImageOutput = AVCapturePhotoOutput()
+                if session.canAddOutput(self.stillImageOutput!) {
+                    session.addOutput(self.stillImageOutput!)
+                }
+
+                self.captureSession = session
+                single(.success(session))
+            } catch {
+                single(.failure(error))
+            }
+
+            return Disposables.create {
+                session.stopRunning()
+            }
+        }
+    }
+
+    // 사진 촬영
+    func capturePhoto() -> Single<Data> {
+        return Single.create { [weak self] single in
+            guard let self else {
+                single(.failure(NSError(domain: "ObjectError", code: -3, userInfo: [NSLocalizedDescriptionKey: "Object of this method is nil"])))
+                return Disposables.create()
+            }
+            guard let stillImageOutput = self.stillImageOutput else {
+                single(.failure(NSError(domain: "PhotoError", code: -2, userInfo: [NSLocalizedDescriptionKey: "Still image output not available"])))
+                return Disposables.create()
+            }
+
+            let settings = AVCapturePhotoSettings()
+            self.photoCaptureCompletion = { result in
+                switch result {
+                case .success(let data):
+                    single(.success(data))
+                case .failure(let error):
+                    single(.failure(error))
+                }
+            }
+            stillImageOutput.capturePhoto(with: settings, delegate: self)
+
+            return Disposables.create()
+        }
+    }
+
+    func startMonitoring() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.captureSession?.startRunning()
+        }
+    }
+
+    func stopMonitoring() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.captureSession?.stopRunning()
+        }
+    }
+}
+
+extension DefaultCameraRepository: AVCapturePhotoCaptureDelegate {
+
+    // 사진 처리 완료 시 호출
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        if let error {
+            photoCaptureCompletion?(.failure(error))
+        } else if let imageData = photo.fileDataRepresentation() {
+            photoCaptureCompletion?(.success(imageData))
+        } else {
+            photoCaptureCompletion?(.failure(NSError(domain: "PhotoError", code: -3, userInfo: [NSLocalizedDescriptionKey: "Failed to process photo data"])))
+        }
+    }
+}

--- a/Wasap/Wasap/Features/WifiAutoConnect/UseCase/CameraUseCase.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/UseCase/CameraUseCase.swift
@@ -1,0 +1,35 @@
+//
+//  CameraUseCase.swift
+//  Wasap
+//
+//  Created by chongin on 10/6/24.
+//
+
+import Foundation
+import UIKit
+import RxSwift
+import AVFoundation
+
+final class CameraUseCase {
+    private let repository: CameraRepository
+
+    init(repository: CameraRepository) {
+        self.repository = repository
+    }
+
+    func startCameraPreview() -> Single<AVCaptureSession> {
+        return repository.configureCamera()
+    }
+
+    func takePhoto() -> Single<Data> {
+        return repository.capturePhoto()
+    }
+
+    func startRunning() {
+        repository.startMonitoring()
+    }
+
+    func stopRunning() {
+        repository.stopMonitoring()
+    }
+}

--- a/Wasap/Wasap/Features/WifiAutoConnect/UseCase/CameraUseCase.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/UseCase/CameraUseCase.swift
@@ -17,19 +17,37 @@ final class CameraUseCase {
         self.repository = repository
     }
 
-    func startCameraPreview() -> Single<AVCaptureSession> {
+    func configureCamera() -> Single<Void> {
         return repository.configureCamera()
+            .map { _ in () }
     }
 
-    func takePhoto() -> Single<Data> {
+    func takePhoto() -> Single<UIImage> {
         return repository.capturePhoto()
+            .map {
+                guard let image = UIImage(data: $0) else {
+                    throw CameraErrors.imageConvertError
+                }
+                return image
+            }
+    }
+
+    func getCapturePreviewLayer() -> Single<AVCaptureVideoPreviewLayer> {
+        Single.create { [weak self] single in
+            guard let previewLayer = self?.repository.previewLayer else {
+                single(.failure(CameraErrors.previewLayerError))
+                return Disposables.create()
+            }
+            single(.success(previewLayer))
+            return Disposables.create()
+        }
     }
 
     func startRunning() {
-        repository.startMonitoring()
+        repository.startRunning()
     }
 
     func stopRunning() {
-        repository.stopMonitoring()
+        repository.stopRunning()
     }
 }

--- a/Wasap/Wasap/Features/WifiAutoConnect/UseCase/DefaultCameraUseCase.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/UseCase/DefaultCameraUseCase.swift
@@ -10,7 +10,15 @@ import UIKit
 import RxSwift
 import AVFoundation
 
-final class CameraUseCase {
+protocol CameraUseCase {
+    func configureCamera() -> Single<Void>
+    func takePhoto() -> Single<UIImage>
+    func getCapturePreviewLayer() -> Single<AVCaptureVideoPreviewLayer>
+    func startRunning()
+    func stopRunning()
+}
+
+final class DefaultCameraUseCase: CameraUseCase {
     private let repository: CameraRepository
 
     init(repository: CameraRepository) {

--- a/Wasap/Wasap/Features/WifiAutoConnect/ViewController/CameraViewController.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/ViewController/CameraViewController.swift
@@ -1,0 +1,131 @@
+//
+//  CameraViewController.swift
+//  Wasap
+//
+//  Created by chongin on 10/7/24.
+//
+
+import UIKit
+import AVFoundation
+import RxSwift
+
+class CameraViewController: UIViewController {
+    private let cameraUseCase: CameraUseCase
+    private var captureSession: AVCaptureSession?
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private let disposeBag = DisposeBag()
+
+    private var previewContainerView: UIView!  // 프리뷰 레이어를 담을 뷰
+    private var capturedImageView: UIImageView!
+    private var takePhotoButton: UIButton!
+
+    init(cameraUseCase: CameraUseCase) {
+        self.cameraUseCase = cameraUseCase
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupPreviewContainerView()
+        setupCapturedImageView()
+        setupTakePhotoButton()
+
+        cameraUseCase.startCameraPreview()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] session in
+                self?.captureSession = session
+                self?.setupPreviewLayer()
+            }, onFailure: { error in
+                print("Error starting camera preview: \(error.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
+    }
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = previewContainerView.bounds
+    }
+
+    private func setupPreviewContainerView() {
+        previewContainerView = UIView()
+        previewContainerView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(previewContainerView)
+
+        NSLayoutConstraint.activate([
+            previewContainerView.topAnchor.constraint(equalTo: view.topAnchor),
+            previewContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            previewContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            previewContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+
+    private func setupPreviewLayer() {
+        guard let captureSession = captureSession else { return }
+        previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
+        previewLayer?.videoGravity = .resizeAspectFill
+        if let previewLayer = previewLayer {
+            previewContainerView.layer.addSublayer(previewLayer)
+        }
+        DispatchQueue.main.async {
+            captureSession.startRunning()
+        }
+    }
+
+    private func setupCapturedImageView() {
+        capturedImageView = UIImageView()
+        capturedImageView.contentMode = .scaleAspectFit
+        capturedImageView.isHidden = true
+        capturedImageView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(capturedImageView)
+
+        NSLayoutConstraint.activate([
+            capturedImageView.topAnchor.constraint(equalTo: view.topAnchor),
+            capturedImageView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            capturedImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            capturedImageView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+
+    private func setupTakePhotoButton() {
+        takePhotoButton = UIButton(type: .system)
+        takePhotoButton.setTitle("Take Photo", for: .normal)
+        takePhotoButton.backgroundColor = .systemBlue
+        takePhotoButton.setTitleColor(.white, for: .normal)
+        takePhotoButton.layer.cornerRadius = 8
+        takePhotoButton.translatesAutoresizingMaskIntoConstraints = false
+        takePhotoButton.addTarget(self, action: #selector(didPressTakePhoto), for: .touchUpInside)
+        view.addSubview(takePhotoButton)
+
+        NSLayoutConstraint.activate([
+            takePhotoButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            takePhotoButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
+            takePhotoButton.widthAnchor.constraint(equalToConstant: 100),
+            takePhotoButton.heightAnchor.constraint(equalToConstant: 50)
+        ])
+    }
+
+    @objc func didPressTakePhoto() {
+        cameraUseCase.takePhoto()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] imageData in
+                guard let self = self, let image = UIImage(data: imageData) else { return }
+                self.displayCapturedPhoto(image)
+                print("Photo captured successfully")
+            }, onFailure: { error in
+                print("Error capturing photo: \(error.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func displayCapturedPhoto(_ image: UIImage) {
+        capturedImageView.image = image
+        capturedImageView.isHidden = false
+        previewContainerView.isHidden = true
+        takePhotoButton.isHidden = true
+    }
+}
+

--- a/Wasap/Wasap/Features/WifiAutoConnect/ViewController/CameraViewController.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/ViewController/CameraViewController.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import RxSwift
 
 class CameraViewController: UIViewController {
-    private let cameraUseCase: CameraUseCase
+    private let cameraUseCase: DefaultCameraUseCase
     private var previewLayer: AVCaptureVideoPreviewLayer?
     private let disposeBag = DisposeBag()
 
@@ -18,7 +18,7 @@ class CameraViewController: UIViewController {
     private var capturedImageView: UIImageView!
     private var takePhotoButton: UIButton!
 
-    init(cameraUseCase: CameraUseCase) {
+    init(cameraUseCase: DefaultCameraUseCase) {
         self.cameraUseCase = cameraUseCase
         super.init(nibName: nil, bundle: nil)
     }

--- a/Wasap/WasapTests/WifiAutoConnect/UseCase/CameraUseCaseTests.swift
+++ b/Wasap/WasapTests/WifiAutoConnect/UseCase/CameraUseCaseTests.swift
@@ -84,7 +84,7 @@ struct CameraUseCaseTests {
     func testStartCameraPreviewSuccess() throws {
 
         // UseCase 실행
-        let result = try? cameraUseCase.configureCamera().toBlocking().first()
+        let result: Void? = try? cameraUseCase.configureCamera().toBlocking().first()
 
         // 결과 검증
         try #require(result != nil)

--- a/Wasap/WasapTests/WifiAutoConnect/UseCase/CameraUseCaseTests.swift
+++ b/Wasap/WasapTests/WifiAutoConnect/UseCase/CameraUseCaseTests.swift
@@ -1,0 +1,107 @@
+//
+//  CameraUseCaseTests.swift
+//  Wasap
+//
+//  Created by chongin on 10/7/24.
+//
+
+import RxSwift
+import AVFoundation
+@testable import Wasap
+import Testing
+import RxSwift
+import RxBlocking
+import UIKit
+
+class MockCameraRepository: NSObject, CameraRepository {
+    var captureSession: AVCaptureSession?
+    private var stillImageOutput: AVCapturePhotoOutput?
+
+    // 카메라 프리뷰 설정
+    func configureCamera() -> Single<AVCaptureSession> {
+        return Single.create { [weak self] single in
+            guard let self = self else { return Disposables.create() }
+            let mockSession = AVCaptureSession()
+            mockSession.sessionPreset = .photo
+
+            self.stillImageOutput = AVCapturePhotoOutput()
+            if mockSession.canAddOutput(self.stillImageOutput!) {
+                mockSession.addOutput(self.stillImageOutput!)
+            }
+
+            self.captureSession = mockSession
+            single(.success(mockSession))
+
+            return Disposables.create {
+                mockSession.stopRunning()
+            }
+        }
+    }
+
+    // 사진 촬영
+    func capturePhoto() -> Single<Data> {
+        return Single.create { single in
+            if let mockImage = UIImage(systemName: "star")?.pngData() {
+                single(.success(mockImage as Data))
+            }
+
+            return Disposables.create()
+        }
+    }
+
+    func startMonitoring() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.captureSession?.startRunning()
+        }
+    }
+
+    func stopMonitoring() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.captureSession?.stopRunning()
+        }
+    }
+}
+
+/// CameraUseCaseTests
+struct CameraUseCaseTests {
+    var mockRepository: MockCameraRepository!
+    var cameraUseCase: CameraUseCase!
+
+    init() async throws {
+        mockRepository = MockCameraRepository()
+        cameraUseCase = CameraUseCase(repository: mockRepository)
+    }
+
+    /// 카메라 프리뷰 시작 테스트
+    @Test
+    func testStartCameraPreviewSuccess() throws {
+
+        // UseCase 실행
+        let result = try? cameraUseCase.startCameraPreview().toBlocking().first()
+
+        // 결과 검증
+        try #require(result != nil)
+        #expect(result == mockRepository.captureSession)
+    }
+
+    /// 사진 촬영 성공 테스트
+    @Test
+    func testTakePhotoSuccess() throws {
+        // camera preview 실행
+        _ = try cameraUseCase.startCameraPreview().toBlocking().first()
+
+        try testStartCameraPreviewSuccess()
+
+        cameraUseCase.startRunning()
+
+        // Mock 데이터 설정
+        let mockPhotoData = UIImage(systemName: "star")?.pngData()
+
+        // UseCase 실행
+        let result = try? cameraUseCase.takePhoto().toBlocking().first()
+
+        // 결과 검증
+        try #require(result != nil)
+        #expect(result == mockPhotoData)
+    }
+}

--- a/Wasap/WasapTests/WifiAutoConnect/UseCase/CameraUseCaseTests.swift
+++ b/Wasap/WasapTests/WifiAutoConnect/UseCase/CameraUseCaseTests.swift
@@ -63,6 +63,12 @@ class MockCameraRepository: NSObject, CameraRepository {
     }
 }
 
+class MockAVCapturePhoto: AVCapturePhoto {
+    static var mockData: Data? = {
+        UIImage(systemName: "star")?.pngData()
+    }()
+}
+
 /// CameraUseCaseTests
 struct CameraUseCaseTests {
     var mockRepository: MockCameraRepository!
@@ -94,14 +100,10 @@ struct CameraUseCaseTests {
 
         cameraUseCase.startRunning()
 
-        // Mock 데이터 설정
-        let mockPhotoData = UIImage(systemName: "star")?.pngData()
-
         // UseCase 실행
         let result = try? cameraUseCase.takePhoto().toBlocking().first()
 
         // 결과 검증
-        try #require(result?.pngData() != nil)
-        #expect(result?.pngData() == mockPhotoData)
+        try #require(result != nil)
     }
 }

--- a/Wasap/WasapTests/WifiAutoConnect/UseCase/CameraUseCaseTests.swift
+++ b/Wasap/WasapTests/WifiAutoConnect/UseCase/CameraUseCaseTests.swift
@@ -72,11 +72,11 @@ class MockAVCapturePhoto: AVCapturePhoto {
 /// CameraUseCaseTests
 struct CameraUseCaseTests {
     var mockRepository: MockCameraRepository!
-    var cameraUseCase: CameraUseCase!
+    var cameraUseCase: DefaultCameraUseCase!
 
     init() async throws {
         mockRepository = MockCameraRepository()
-        cameraUseCase = CameraUseCase(repository: mockRepository)
+        cameraUseCase = DefaultCameraUseCase(repository: mockRepository)
     }
 
     /// 카메라 프리뷰 시작 테스트


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
카메라 유스케이스를 제작하였습니다.
* 카메라 설정 : 카메라를 동작시키기 위한 기본 세팅을 진행합니다.
* 사진 찍기 : 카메라로 사진을 찍는 동작을 수행합니다.
* 프리뷰 레이어 가져오기 : 사진을 찍기 전 프리뷰가 나오는 레이어를 가져옵니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #1 


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
카메라를 뷰 없이 유스케이스로만 만들고 테스트하기가 굉장히 까다롭다고 느꼈습니다.
프리뷰 레이어는 캡쳐 세션이 완성되고 나서 만들 수 있고, 이를 만든 다음 뷰에서 올려야 합니다. 따라서 Single 안에 AVCaptureVideoPreviewLayer가 전달됩니다. 사실 AVFoundation 의존성이 필수라도 생각해서 어쩔 수 없다고 생각합니다..

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
<details> <summary>나름 혼자 정리한 카메라 찍는 방법</summary>

# 카메라 프리뷰

### AVCaptureSession

https://developer.apple.com/documentation/avfoundation/avcapturesession

캡쳐 동작을 구성하고 입력 장치에서 캡쳐 출력으로의 데이터 흐름을 조정하는 객체.

실시간 캡쳐를 수행하기 위해서는 capture session을 만들고 적절한 input과 output을 추가한다. 

input으로는 AVCaptureInput을 상속받는 친구들로, output으로는 AVCaptureOutput을 상속받는 친구들로 구성한다.

startRunning()으로 시작하면 된다.

stopRunning()으로 중지하면 된다.

### AVCaptureDevice

카메라나 마이크처럼 하드웨어나 가상 캡쳐 디바이스를 나타내는 객체.

Capture Devices는 미디어 데이터를 capture session의 input으로 연결할 수 있다.

device의 인스턴스를 직접 만들지 말고 AVCaptureDevice.DiscoverySession이나 default 메소드를 활용해서 가져오자.

### AVCapturePhotoOutput

still image, Live Photos, 혹은 다른 사진 워크플로우같은 capture output을 나타냄.

RAW 포멧의 DNG 파일, HEVC 포멧의 HEIF 파일, JPEG 파일로 내보낼 수 있다.

# 카메라 사진 찍기

AVCapturePhotoOutput을 사용해서 사진 캡쳐하는 방법:

1. AVCapturePhotoOutput 객체 만들기. 
2. AVCapturePhotoSettings객체를 만들고 설정하여 특정 캡쳐에 대해 세팅하기 (손떨림 방지나 플래쉬같은거)
3. AVCapturePhotoCaptureDelegate 프로토콜을 채택하면 capturePhoto(with:delegate:) 메소드에 캡쳐된 이미지를 꽂아준다.
</details>


## 🔥 Test
<!-- Test -->
<img width="471" alt="image" src="https://github.com/user-attachments/assets/316ae01c-b294-4360-b099-433a46a7d4a6">

