### PR TITLE
[refactor] 공유하기 집계방식 수정 및 공유받기 모달 시 QR/OCR 막도록 개선

### DIFF
--- a/Wasap/Wasap/Features/WifiAutoConnect/Coordinator/CameraCoordinator.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/Coordinator/CameraCoordinator.swift
@@ -50,8 +50,6 @@ extension CameraCoordinator: CameraCoordinatorController {
             let coordinator = ScanCoordinator(navigationController: navigationController, wifiAutoConnectDIContainer: wifiAutoConnectDIContainer, previewImage: imageData)
             start(childCoordinator: coordinator)
         case .connectWithQR(let ssid, let password):
-            self.removeChildCoordinators()
-
             let coordinator = ConnectingCoordinator(navigationController: navigationController, wifiAutoConnectDIContainer: wifiAutoConnectDIContainer, imageData: nil, ssid: ssid, password: password)
             start(childCoordinator: coordinator)
         case .receiving(ssid: let ssid, password: let password):

--- a/Wasap/Wasap/Features/WifiAutoConnect/ViewController/ReceivingViewController.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/ViewController/ReceivingViewController.swift
@@ -9,11 +9,15 @@ import RxSwift
 import RxCocoa
 import UIKit
 
-public class ReceivingViewController: RxBaseViewController<ReceivingViewModel> {
+public class ReceivingViewController: RxBaseViewController<ReceivingViewModel>, UIAdaptivePresentationControllerDelegate {
     private let receivingView = ReceivingView()
 
     public override func viewDidLoad() {
         super.viewDidLoad()
+        self.presentationController?.delegate = self
+
+        Log.print("Notification sent: receivingViewDidPresent")
+        NotificationCenter.default.post(name: .receivingViewDidPresent, object: nil)
     }
 
     public override func loadView() {
@@ -44,6 +48,15 @@ public class ReceivingViewController: RxBaseViewController<ReceivingViewModel> {
         viewModel.ssidDriver
             .drive(receivingView.ssidLabel.rx.text)
             .disposed(by: disposeBag)
-
     }
+
+    deinit {
+        Log.print("Notification sent: receivingViewDidDismiss")
+        NotificationCenter.default.post(name: .receivingViewDidDismiss, object: nil)
+    }
+}
+
+extension Notification.Name {
+    static let receivingViewDidPresent = Notification.Name("receivingViewDidPresent")
+    static let receivingViewDidDismiss = Notification.Name("receivingViewDidDismiss")
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 공유하기의 접속자 수 집계 방식을 수정하였습니다. 실시간 연결되어있는 피어 수를 표시하는 방식에서 총(누적) 수신받은 피어 수를  
표시하는 방식으로 바꿨습니다.
- 공유받기 모달이 올라온 경우, 시트 너머에 보이는 부모 뷰(카메라 뷰)의 OCR/QR 접속 시도가 막히도록 개선하였습니다. 모달을 x버튼 또는 스와이프 제스처로 내릴 경우 OCR/QR 기능이 재개됩니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #78 


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
CameraViewModel에 isScanningEnabled 프로퍼티를 넣고 공유받기 모달의 on/off 상태에 따라 이를 조정하여 OCR/QR 작동 여부를 제어하고자 하였습니다. 방법으로 NotificationCenter를 사용하여 감지하도록 구현하였습니다. 처음엔 CameraViewModel에서 viewWillAppear, viewWillDisappear를 사용해보고자 하였지만 안되었고, 그외 ReceivingCoordinator 내에서 CameraViewModel를 제어하는 방식 외엔 찾지 못하여 NotificationCenter를 도입하였습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

https://github.com/user-attachments/assets/817830f7-8152-41d1-9547-aa3d41d4f6c2




## 🔥 Test
<!-- Test -->

